### PR TITLE
Add phone number footer

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -27,7 +27,15 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" className={`${inter.variable} ${notoBengali.variable}`}>
-      <body>{children}</body>
+      <body>
+        {children}
+        <footer
+          className="text-center py-6 text-sm ui-text"
+          style={{ color: "var(--color-muted)" }}
+        >
+          01234564509
+        </footer>
+      </body>
     </html>
   )
 }


### PR DESCRIPTION
## Summary
- add a simple footer to the layout with phone number 01234564509

## Testing
- `npm run lint` *(fails: asks to configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_687cc9053d98832cb641845ecbacea9d